### PR TITLE
Add support for multiple rel values when checking for external links

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@caurateam/sapper",
-  "version": "0.30.3",
+  "version": "0.30.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@caurateam/sapper",
-  "version": "0.30.3",
+  "version": "0.30.4",
   "description": "The next small thing in web development, powered by Svelte",
   "bin": {
     "sapper": "./sapper"

--- a/runtime/src/app/router/index.ts
+++ b/runtime/src/app/router/index.ts
@@ -147,8 +147,12 @@ function handle_click(event: MouseEvent) {
 
 	// Ignore if tag has
 	// 1. 'download' attribute
-	// 2. rel='external' attribute
-	if (a.hasAttribute('download') || a.getAttribute('rel') === 'external') return;
+	// 2. 'rel' attribute includes external
+	const rel = a.getAttribute('rel')?.split(/\s+/);
+
+	if (a.hasAttribute('download') || (rel && rel.includes('external'))) {
+		return;
+	}
 
 	// Ignore if <a> has a target
 	if (svg ? (<SVGAElement>a).target.baseVal : a.target) return;


### PR DESCRIPTION
This fix was done in Svelte Kit https://github.com/sveltejs/kit/pull/884

Currently Sapper only lets the browser take over handling links if the `rel` attribute is exactly `external`:
```
rel="external"
```
This breaks if anything else is added, such as "noreferrer".

This PR adds support for multiple rel values with external:
```
rel="external noreferrer"
```