### PR TITLE
Do not re-run preload when the session changes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@caurateam/sapper",
-  "version": "0.30.4",
+  "version": "0.30.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@caurateam/sapper",
-  "version": "0.30.4",
+  "version": "0.30.5",
   "description": "The next small thing in web development, powered by Svelte",
   "bin": {
     "sapper": "./sapper"

--- a/runtime/src/app/app.ts
+++ b/runtime/src/app/app.ts
@@ -41,13 +41,11 @@ const stores = {
 };
 
 let $session: any;
-let session_dirty: boolean;
 
 stores.session.subscribe(async value => {
 	$session = value;
 
 	if (!ready) return;
-	session_dirty = true;
 
 	const dest = select_target(new URL(location.href));
 
@@ -165,7 +163,6 @@ async function render(branch: Branch, props: any, page: PageContext) {
 	current_branch = branch;
 	current_query = JSON.stringify(page.query);
 	ready = true;
-	session_dirty = false;
 }
 
 function part_changed(i, segment, match, stringified_query) {
@@ -183,6 +180,8 @@ function part_changed(i, segment, match, stringified_query) {
 			return true;
 		}
 	}
+
+	return false;
 }
 
 export async function hydrate_target(dest: Target): Promise<HydratedTarget> {
@@ -238,7 +237,7 @@ export async function hydrate_target(dest: Target): Promise<HydratedTarget> {
 
 			let result;
 
-			if (!session_dirty && !segment_dirty && current_branch[i] && current_branch[i].part === part.i) {
+			if (!segment_dirty && current_branch[i] && current_branch[i].part === part.i) {
 				result = current_branch[i];
 			} else {
 				segment_dirty = false;

--- a/test/apps/session/test.ts
+++ b/test/apps/session/test.ts
@@ -28,7 +28,7 @@ describe('session', function() {
 		assert.strictEqual(await r.text('h1'), 'changed');
 	});
 
-	it('preloads session props', async () => {
+	it('session props are not reactive', async () => {
 		await r.load('/preloaded');
 
 		assert.strictEqual(await r.text('h1'), 'hello world');
@@ -37,7 +37,7 @@ describe('session', function() {
 		assert.strictEqual(await r.text('h1'), 'hello world');
 
 		await r.page.click('button');
-		assert.strictEqual(await r.text('h1'), 'changed');
+		assert.strictEqual(await r.text('h1'), 'hello world');
 	});
 
 	it('survives exception from session getter', async () => {


### PR DESCRIPTION
### Background
Currently, the `preload` function for a route component runs in certain cases

1. **The user browses to the route**
This is obvious, it's about to render the route.
2. **The `page` store has changed**
Makes sense, a param could change requiring completely different data (e.g. `blog/[slug].svelte`)
3. **The `session` store has changed**
Here is the problem...

### The original thinking behind this:
> if you're on a page that redirects to a login page if there's no user object, or otherwise preloads data specific to that user, then logging out won't automatically update the page — you could easily end up with a page like

```
HOME   ABOUT                                                                      LOG IN
-----------------------------------------------------------------------------------------

Secret, user-specific data that shouldn't be visible alongside a 'log in' button:

* foo
* bar
* baz
```

### The actual issue

This "reactivity" of the session store only actually happens if you change the session store **_in the client side_**. In which case (where I've found an issue many times) you're already doing something else and don't want the page to render again for no reason. In the example above, if you "logout" then perhaps there is other code that needs to run before we route back to the "signed out" page. In the case where there is a redirect in the preload, that would be a client side routing... what if we want to force native browser navigation, etc.

So there are many reasons why this is not intuitive and actually causes more problems. There's talk in a SvelteKit issue of making this explicit. Allowing developers to decide when this should be reactive. For our use though, we don't want this to be reactive and can structure our Sapper app with this in mind.

### The solution

This PR prevents preload from being called when the session changes. I've tested this out locally in a few cases and updated the test to reflect it.

Note: This does not prevent the session store updates from being reflected in the client in a normal Svelte way (i.e. the session is still reactive)